### PR TITLE
Fix Vercel runtime configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,15 @@
 {
-
-  
+  "version": 2,
+  "functions": {
+    "api/*.py": {
+      "runtime": "vercel-python@5.0.5",
+      "maxDuration": 10,
+      "memory": 1024
+    }
+  },
+  "rewrites": [
+    { "source": "/", "destination": "/api/index" },
+    { "source": "/mcp", "destination": "/api/index" },
+    { "source": "/mcp/(.*)", "destination": "/api/index" }
+  ]
 }


### PR DESCRIPTION
## Summary
- update the Vercel function runtime to the current vercel-python builder
- extend rewrites so /mcp and its subpaths resolve to the ASGI entrypoint

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd02530ecc83219d4bb5a0ffd4d69a