### PR TITLE
Use Python 3.11 runtime in Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,15 @@
 {
-
-  
+  "version": 2,
+  "functions": {
+    "api/**/*.py": {
+      "runtime": "python3.11",
+      "maxDuration": 10,
+      "memory": 1024
+    }
+  },
+  "rewrites": [
+    { "source": "/", "destination": "/api/index" },
+    { "source": "/mcp", "destination": "/api/index" },
+    { "source": "/mcp/(.*)", "destination": "/api/index" }
+  ]
 }


### PR DESCRIPTION
## Summary
- set the Vercel Python functions to use the `python3.11` runtime
- widen the function glob to include any nested API modules while retaining resource limits

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd02530ecc83219d4bb5a0ffd4d69a