### PR TITLE
Fix vercel.json configuration format

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,12 @@
 {
   "version": 2,
   "functions": {
+    "api/**/*.py": {
       "maxDuration": 10,
       "memory": 1024
     }
-  ,
+  },
   "rewrites": [
-    { "source": "/", "destination": "/api/index" },
+    { "source": "/", "destination": "/api/index" }
   ]
 }


### PR DESCRIPTION
## Summary
- correct the Vercel configuration JSON formatting
- scope the serverless function settings to Python API routes
- remove the trailing comma in the rewrites array entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0999863483218cca9331763aacb3