### PR TITLE
Import FastMCP server dependency

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,12 @@
 {
   "version": 2,
   "functions": {
+    "api/**/*.py": {
       "maxDuration": 10,
       "memory": 1024
     }
-  ,
+  },
   "rewrites": [
-    { "source": "/", "destination": "/api/index" },
+    { "source": "/", "destination": "/api/index" }
   ]
 }

--- a/worldtime_server.py
+++ b/worldtime_server.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 import httpx
+from mcp.server.fastmcp import FastMCP
 
 
 # Configure the MCP server for both local execution (stdio transport) and


### PR DESCRIPTION
## Summary
- add the missing FastMCP import so the server initializes correctly on deployment

## Testing
- python -m compileall worldtime_server.py api/index.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0999863483218cca9331763aacb3