### PR TITLE
Handle Vercel rewrite for root health check

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -12,6 +12,7 @@ app = server.streamable_http_app()
 
 
 @app.route("/")
+@app.route("/api/index")
 async def root(_: Request) -> JSONResponse:
     """Provide a simple health endpoint for Vercel deployments."""
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,12 @@
 {
   "version": 2,
   "functions": {
+    "api/**/*.py": {
       "maxDuration": 10,
       "memory": 1024
     }
-  ,
+  },
   "rewrites": [
-    { "source": "/", "destination": "/api/index" },
+    { "source": "/", "destination": "/api/index" }
   ]
 }

--- a/worldtime_server.py
+++ b/worldtime_server.py
@@ -5,6 +5,7 @@ import json
 from typing import Any
 
 import httpx
+from mcp.server.fastmcp import FastMCP
 
 
 # Configure the MCP server for both local execution (stdio transport) and


### PR DESCRIPTION
## Summary
- register the health endpoint on `/api/index` so Vercel rewrites resolve to the same JSON response

## Testing
- python -m compileall api/index.py

------
https://chatgpt.com/codex/tasks/task_e_68dd0999863483218cca9331763aacb3