### PR TITLE
Add rewrites for MCP endpoint on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,8 @@
     }
   },
   "rewrites": [
-    { "source": "/", "destination": "/api/index" }
+    { "source": "/", "destination": "/api/index" },
+    { "source": "/mcp", "destination": "/api/index" },
+    { "source": "/mcp/(.*)", "destination": "/api/index" }
   ]
 }


### PR DESCRIPTION
## Summary
- add Vercel rewrites so /mcp requests are routed to the FastMCP serverless function

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd12ff50648321a32d603c54da414b