### PR TITLE
Enable streaming support on Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,11 +2,15 @@
   "version": 2,
   "functions": {
     "api/**/*.py": {
-      "maxDuration": 10,
-      "memory": 1024
+      "maxDuration": 300,
+      "memory": 1024,
+      "supportsResponseStreaming": true,
+      "runtime": "python3.11"
     }
   },
   "rewrites": [
-    { "source": "/", "destination": "/api/index" }
+    { "source": "/", "destination": "/api/index" },
+    { "source": "/mcp", "destination": "/api/index" },
+    { "source": "/mcp/(.*)", "destination": "/api/index" }
   ]
 }


### PR DESCRIPTION
## Summary
- enable response streaming for the Python serverless function so the MCP SSE endpoint stays open on Vercel
- increase the Vercel function timeout to accommodate long-lived MCP sessions and pin the runtime to Python 3.11

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd12ff50648321a32d603c54da414b